### PR TITLE
MVP for online statuses

### DIFF
--- a/frontend/src/components/AppNav.vue
+++ b/frontend/src/components/AppNav.vue
@@ -24,7 +24,7 @@ export default {
   data() {
     return {
       name: auth.getUserName(),
-      pictureUrl: auth.getUserPicture(),
+      pictureUrl: auth.getProfileThumbnailUrl(),
     };
   },
   methods: {

--- a/frontend/src/components/OnlineNow.vue
+++ b/frontend/src/components/OnlineNow.vue
@@ -1,0 +1,68 @@
+<!-- HTML -->
+<template>
+  <div class="online-box">
+        <div class="user-row">
+          <span>Who's online:</span>
+          <div class="avatar" v-for="user in users"><span></span>
+            <div class="tooltip2">
+              <span class="tooltiptext">{{ user.displayName }}</span>
+              <img :src="user.profileImageUrl" :alt="user.displayName" height="50px" width="50px"></img>
+            </div>
+          </div>
+        </div>
+  </div>
+</template>
+
+<!-- JavaScript -->
+<script>
+
+export default {
+  name: 'online-now',
+  computed: {
+    users() {
+      var listOfUserData = Object.keys(this.$store.state.onlineUsers).map((key) => {
+        return this.$store.state.onlineUsers[key];
+      });
+      return listOfUserData;
+    }
+  }
+};
+</script>
+
+<!-- CSS -->
+<style scoped>
+.online-box {
+  text-align: left;
+}
+
+.avatar {
+  display: inline-block;
+}
+
+/* Space only between elements */
+.avatar + .avatar {
+  margin-left: 10px;
+}
+
+.tooltip2 {
+  position: relative;
+  display: inline-block;
+}
+
+/* Tooltip text */
+.tooltip2 .tooltiptext {
+    visibility: hidden;
+    background-color: #31708f;
+    color: #fff;
+    text-align: center;
+    height: 50px;
+    width: 50px;
+ 
+    position: absolute;
+    z-index: 1;
+}
+
+.tooltip2:hover .tooltiptext {
+    visibility: visible;
+}
+</style>

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -18,7 +18,7 @@ export function createStore() {
           events: [],
           collaborators: [],
         },
-        onlineUsers: [],
+        onlineUsers: {}, // map of user IDs to their details
         focusedEvent: {}
       },
       getters: {},    // currently useless
@@ -79,14 +79,7 @@ export function createStore() {
           api.updateEvent(event);
         },
         socket_connect: (store, data) => {
-          var tok = localStorage.getItem('id_token');
-          if (!tok) {
-            tok = 'Unknown user';
-          }
-          (new Vue()).$socket.emit('newConnection', {
-            userID: tok,
-            tripID: store.state.trip.id,
-          });
+            console.log("Connected to server socket");
         },
         socket_activeUsers: (store, data) => {
             store.commit('updateOnlineUsers', data['usersConnected']);

--- a/frontend/src/views/TripDetail.vue
+++ b/frontend/src/views/TripDetail.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="full-width">
+    <online-now/>
     <input type="text" class="text-center title textbox" v-model="trip.name" placeholder="The best trip ever!"/>
     <div class="whitespace-top">
       <timeline :trip="trip" class="col-sm-5"></timeline>
@@ -11,12 +12,17 @@
 <script>
 import Timeline from '../components/Timeline';
 import CardDetailView from '../components/CardDetailView';
+import OnlineNow from '../components/OnlineNow';
+
+import {getTripSocket} from '../../utils/socket';
+import {getUserName, getProfileThumbnailUrl} from '../../utils/auth';
 
 export default {
   name: 'trip-detail',
   components: {
     Timeline,
     CardDetailView,
+    OnlineNow,
   },
   computed: {
     trip() {
@@ -26,9 +32,31 @@ export default {
       return this.$route.params.id;
     },
   },
+
   mounted() {
     this.$store.dispatch('getTrip', this.tripID);
   },
+
+  created() {
+    var tok = localStorage.getItem('id_token');
+    if (!tok) {
+      tok = 'Unknown user';
+    }
+
+    getTripSocket().emit('newConnection', {
+      userID: tok,
+      tripID: this.trip.id,
+      userName: getUserName(),
+      profileImageUrl: getProfileThumbnailUrl(),
+    });
+
+    console.log('Connecting to trip');
+  },
+
+  destroyed() {
+    getTripSocket().emit('removeConnection', {});
+    console.log('Disconnecting from trip');
+  }
 };
 </script>
 

--- a/frontend/utils/auth.js
+++ b/frontend/utils/auth.js
@@ -23,7 +23,7 @@ const ID_TOKEN_KEY = 'id_token';
 const ACCESS_TOKEN_KEY = 'access_token';
 const TOKEN_EXPIRE = 'token_expire';
 const USER_NAME = 'user_name';
-const USER_PICTURE = 'user_picture';
+const PROFILE_THUMBNAIL = 'profile_thumbnail';
 
 var router = new Router({
    mode: 'history',
@@ -57,13 +57,17 @@ function setTokens(authResponse) {
 function configureUser(response) {
   console.log('Successful login for: ' + response.name);
   localStorage.setItem(USER_NAME, response.name);
-  localStorage.setItem(USER_PICTURE, response.picture.data.url);
+  localStorage.setItem(PROFILE_THUMBNAIL, response.picture.data.url);
 }
 
 export function logout() {
+  // FIXME: logout isn't working so clear the tokens regardless of whether the callback is triggered
   clearTokens();
-  FB.logout();
-  router.go('/');
+  FB.logout(function(response) {
+    console.log(response);
+    clearTokens();
+    router.go('/');
+  });
 }
 
 export function getIdToken() {
@@ -78,8 +82,8 @@ export function getUserName() {
   return localStorage.getItem(USER_NAME);
 }
 
-export function getUserPicture() {
-  return localStorage.getItem(USER_PICTURE);
+export function getProfileThumbnailUrl() {
+  return localStorage.getItem(PROFILE_THUMBNAIL);
 }
 
 function getTokenExpirationDate() {

--- a/frontend/utils/socket.js
+++ b/frontend/utils/socket.js
@@ -1,0 +1,5 @@
+import Vue from 'vue';
+
+export function getTripSocket() {
+	return (new Vue()).$socket;
+}


### PR DESCRIPTION
- Change pubsubreg structure to a map from trip ID to map from socket ID to user data. This is necessary because a single user can have multiple windows open and therefore multiple socket instances so we have to keep track of those.
- Change FB profile image fetching names to be more specific
- Add visual component for who is online (pretty ugly)
- Bug: component doesn't load properly (throws error) after navigating away from trip page and back again. Will fix later