### PR TITLE
Fix wrong collaborators displaying

### DIFF
--- a/frontend/src/components/Collaborators.vue
+++ b/frontend/src/components/Collaborators.vue
@@ -55,14 +55,12 @@ export default {
   },
   methods: {
     showCollaboratorModal() {
+      this.$store.dispatch('getCollaborators');
       this.$modal.show('add-collaborator');
     },
     addCollaborator() {
       this.$store.dispatch('addCollaborator', this.email);
     },
-  },
-  mounted() {
-    this.$store.dispatch('getCollaborators');
   },
 };
 </script>


### PR DESCRIPTION
We were always fetching the collaborators for the previously opened trip. This was caused by a race condition between a socket event updating the current trip ID (called during component creation) and retrieving the collaborators using that trip ID (called on mount). I've modified it so that we fetch the collaborators every time the modal is opened (we get the bonus of pseudo-realtime updates). Another option would be to fetch collaborators in a callback after the first socket event succeeds (probably more helpful in the long run if we don't intend on collaborators to be updated real-time).

Not entirely sure if this fixes the issue or if there's more to be done. Will continue testing after this is merged.